### PR TITLE
Automates line-height calcs and simplifies use of border mixins

### DIFF
--- a/_typesettings.scss
+++ b/_typesettings.scss
@@ -104,7 +104,7 @@ $base-line-height: ($base-vertical-unit * $base-line-multi) / $base-font-size;
 // all the wonderful type related stuffs.
 
 // Sets the type in EMs and makes a vertical rhythm unitless line-height that is based on context.
-@mixin setType($lines: $base-line-multi, $font-size: $base-em-font-size) {
+@mixin setType($font-size: $base-em-font-size) {
   font-size: $font-size;
   line-height: ceil($font-size / $base-line-height) * ($base-line-height / $font-size);
 }


### PR DESCRIPTION
Really great work Ian, typesettings is very impressive.

I'm probably missing something vital, but it seems to me that the line-height calculation can be automated so you need only pass the font-size to the setType mixin and get the correct line-height.

This would mean a user cannot unintentionally bork the line-height by passing an inappropriate value to the mixin.
